### PR TITLE
Testing PR - in personal fork - enable utils/fixed-decimal benchmark

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -116,7 +116,7 @@ jobs:
           mkdir -p $REL_OUTPUT_PATH;
           export OUTPUT_PATH_CMD="ls -d $REL_OUTPUT_PATH";
           export OUTPUT_PATH=$(echo $OUTPUT_PATH_CMD | sh);
-          cargo bench -- --output-format bencher | tee $OUTPUT_PATH/output.txt
+          cargo bench -- --output-format bencher | tee $OUTPUT_PATH/output.txt;
           popd
 
       # In the following step(s) regarding converting benchmark output to dashboards, the branch in `gh-pages-branch` needs to exist.

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -91,9 +91,10 @@ jobs:
         component:
           - components/locid
           - components/uniset
-
-          # TODO(#320): re-enable
-          # - utils/fixed_decimal
+          - components/plurals
+          - components/uniset
+          - components/datetime
+          - utils/fixed_decimal
 
 
     # If you are modifying and debugging is required, don't be afraid to get

--- a/components/datetime/src/pattern/mod.rs
+++ b/components/datetime/src/pattern/mod.rs
@@ -57,11 +57,7 @@ impl Pattern {
     }
 
     // TODO(#277): This should be turned into a utility for all ICU4X.
-    pub fn from_bytes_combination(
-        input: &str,
-        date: Self,
-        time: Self,
-    ) -> Result<Self, Error> {
+    pub fn from_bytes_combination(input: &str, date: Self, time: Self) -> Result<Self, Error> {
         Parser::new(input)
             .parse_placeholders(vec![time, date])
             .map(Self)

--- a/components/datetime/src/pattern/parser.rs
+++ b/components/datetime/src/pattern/parser.rs
@@ -52,14 +52,14 @@ impl<'p> Parser<'p> {
                         quoted: false,
                     };
                     chars.next();
-                },
+                }
                 (Segment::Symbol { symbol, length }, false) => {
                     result.push((*symbol, *length).try_into()?);
                     self.state = Segment::Literal {
                         literal: String::new(),
                         quoted: true,
                     };
-                },
+                }
             }
             Ok(true)
         } else if let Segment::Literal {
@@ -328,32 +328,36 @@ mod tests {
             (
                 "y'My'M",
                 vec![
-                (fields::Year::Calendar.into(), FieldLength::One).into(),
-                "My".into(),
-                (fields::Month::Format.into(), FieldLength::One).into(),
+                    (fields::Year::Calendar.into(), FieldLength::One).into(),
+                    "My".into(),
+                    (fields::Month::Format.into(), FieldLength::One).into(),
                 ],
             ),
             (
                 "y 'My' M",
                 vec![
-                (fields::Year::Calendar.into(), FieldLength::One).into(),
-                " My ".into(),
-                (fields::Month::Format.into(), FieldLength::One).into(),
+                    (fields::Year::Calendar.into(), FieldLength::One).into(),
+                    " My ".into(),
+                    (fields::Month::Format.into(), FieldLength::One).into(),
                 ],
             ),
-            (" 'r'. 'y'. ", vec![
-             " r. y. ".into(),
-            ]),
-            ("hh 'o''clock' a", vec![
-             (fields::Hour::H12.into(), FieldLength::TwoDigit).into(),
-             " o'clock ".into(),
-             (fields::DayPeriod::AmPm.into(), FieldLength::One).into(),
-            ]),
-            ("hh''a", vec![
-             (fields::Hour::H12.into(), FieldLength::TwoDigit).into(),
-             "'".into(),
-             (fields::DayPeriod::AmPm.into(), FieldLength::One).into(),
-            ]),
+            (" 'r'. 'y'. ", vec![" r. y. ".into()]),
+            (
+                "hh 'o''clock' a",
+                vec![
+                    (fields::Hour::H12.into(), FieldLength::TwoDigit).into(),
+                    " o'clock ".into(),
+                    (fields::DayPeriod::AmPm.into(), FieldLength::One).into(),
+                ],
+            ),
+            (
+                "hh''a",
+                vec![
+                    (fields::Hour::H12.into(), FieldLength::TwoDigit).into(),
+                    "'".into(),
+                    (fields::DayPeriod::AmPm.into(), FieldLength::One).into(),
+                ],
+            ),
         ];
 
         for (string, pattern) in samples {


### PR DESCRIPTION
The benchmark action for `utils/fixed-decimal` was failing previously for some reason that didn't make sense (given how it is following the same templated workflow job like `components/locid` and `components/unicset`, which succeeded).

This PR sees if,  after re-enabling `utils/fixed-decimal` and the other changes to CI including the benchmark commands, the test will succeed.  Also, new components are included in the list of benchmark tests.